### PR TITLE
Add createKeyframes feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,24 @@ npm install barium --save
 ```
 var Barium = require('barium');
 
+var pulseKeyframes = `
+	0% {
+		transform: scale3d(1, 1, 1);
+	}
+
+	50% {
+		transform: scale3d(1.05, 1.05, 1.05);
+	}
+
+	100% {
+		transform: scale3d(1, 1, 1);
+	}
+`;
+
+var animations = Barium.createKeyframes({
+  pulse: pulseKeyframes
+});
+
 var styles = Barium.create({
   btn: {
     display: 'inline-block',
@@ -57,7 +75,8 @@ var styles = Barium.create({
     userSelect: 'none',
 
     ':hover': {
-      color: '#fff'
+      color: '#fff',
+      animation: `${animations.pulse} .5s infinite`
     },
     // Try resizing the window!
     '@media (max-width: 500px)': {

--- a/src/Barium.js
+++ b/src/Barium.js
@@ -41,5 +41,25 @@ module.exports = {
     appendStyle(cssText);
 
     return ruleMap;
+  },
+  createKeyframes: function(styles) {
+    var cssText = '';
+    var ruleMap = {};
+
+    Object.keys(styles).forEach(function(val, key) {
+          var rules = styles[val];
+          var keyframeName = '_' + hash(JSON.stringify(rules)); // All with ._ prefix
+          var keyframeRule = " @keyframes " + keyframeName + "{" + rules + "} "
+          ruleMap[val] = keyframeName;
+          
+      if(!insertedRuleMap[keyframeName]){
+        cssText += keyframeRule;
+      }
+      insertedRuleMap[keyframeName] = true;          
+    });
+    
+    appendStyle(cssText);
+    
+    return ruleMap;
   }
 }


### PR DESCRIPTION
This fixes #1 by allowing keyframes to be injected by calling `createKeyframes` and passing it an object composed of animation names for keys and keyframe strings for values (not opening the can of worms of using real nested objects with percents for keys)
#### Example

``` javascript
const trembleKeyframes = `
    33% {
        transform: translateX(2px);
    }
    66% {
        transform: translateX(-2px);
    }
    100% {
        transform: translateX(0px);
    }
`;

const animations = Barium.createKeyframes({
    tremble: trembleKeyframes
});


const styles = Barium.create({
    shakey: {
        ":hover": {
            animation: `${animations.tremble} 0.125s infinite alternate`
        }
    }
});
```

this results in the following CSS being injected:

``` css
 @keyframes _-256844057{
    33% {
        transform: translateX(2px);
    }
    66% {
        transform: translateX(-2px);
    }
    100% {
        transform: translateX(0px);
    }
} 
```

and

``` css
.whateverTheHashOfShakeyWas {
    animation:_-256844057 0.125s infinite alternate;
}
```
